### PR TITLE
Dynamically resize when expanding spell info and allow multiple to be…

### DIFF
--- a/src/CharacterSheetItems/Spells/Spell.css
+++ b/src/CharacterSheetItems/Spells/Spell.css
@@ -15,6 +15,20 @@
 .spell-item-expanded-base {
   padding-left: 90px;
   border-bottom: 1px lightslategray solid;
+  max-height: 1200px;
+  overflow: hidden;
+  transition: max-height 1s;
+}
+
+.spell-item-collapsed-base {
+  padding: 3px;
+  padding-left: 90px;
+  font-variant: small-caps;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height cubic-bezier(0, 1.12, 0, 0.66) 0.25s;
+  margin-left: 13px;
+  margin-right: 13px;
 }
 
 .spell-item:hover {

--- a/src/CharacterSheetItems/Spells/Spell.js
+++ b/src/CharacterSheetItems/Spells/Spell.js
@@ -5,7 +5,7 @@ import { ToggleableRadioButton } from "../Controls/ToggleableRadioButton";
 export function Spells({ spells }) {
   const [spellGroup, setSpellGroup] = useState(spells);
   const [currentlyEditing, setCurrentlyEditing] = useState(-1);
-  const [currentlyViewing, setCurrentlyViewing] = useState({});
+  const [currentlyViewing, setCurrentlyViewing] = useState([]);
 
   if (spellGroup == undefined || spellGroup.spells.length == 0) {
     let newstate = { ...spellGroup };
@@ -42,13 +42,14 @@ export function Spells({ spells }) {
   }
 
   function tryView(id) {
-    if (id in currentlyViewing) {
-      let tempViewing = { ...currentlyViewing };
-      delete tempViewing[id];
-      setCurrentlyViewing(tempViewing);
+    const index = currentlyViewing.indexOf(id);
+    let updatedViewing = [...currentlyViewing];
+    if (index > -1) {
+      updatedViewing.splice(index, 1);
     } else {
-      setCurrentlyViewing({ ...currentlyViewing, [id]: true });
+      updatedViewing.push(id);
     }
+    setCurrentlyViewing(updatedViewing);
   }
 
   function updateSpellSlot(increment) {
@@ -73,7 +74,7 @@ export function Spells({ spells }) {
             spell={spell}
             onSpellchange={updateSpellname}
             editing={currentlyEditing === index}
-            viewing={index in currentlyViewing}
+            viewing={currentlyViewing.includes(index)}
             onBeginEdit={tryBeginEdit}
             onEndEdit={tryEndEdit}
             onView={tryView}

--- a/src/CharacterSheetItems/Spells/Spell.js
+++ b/src/CharacterSheetItems/Spells/Spell.js
@@ -5,7 +5,7 @@ import { ToggleableRadioButton } from "../Controls/ToggleableRadioButton";
 export function Spells({ spells }) {
   const [spellGroup, setSpellGroup] = useState(spells);
   const [currentlyEditing, setCurrentlyEditing] = useState(-1);
-  const [currentlyViewing, setCurrentlyViewing] = useState(-1);
+  const [currentlyViewing, setCurrentlyViewing] = useState({});
 
   if (spellGroup == undefined || spellGroup.spells.length == 0) {
     let newstate = { ...spellGroup };
@@ -42,10 +42,12 @@ export function Spells({ spells }) {
   }
 
   function tryView(id) {
-    if (currentlyViewing === id) {
-      setCurrentlyViewing(-1);
+    if (id in currentlyViewing) {
+      let tempViewing = { ...currentlyViewing };
+      delete tempViewing[id];
+      setCurrentlyViewing(tempViewing);
     } else {
-      setCurrentlyViewing(id);
+      setCurrentlyViewing({ ...currentlyViewing, [id]: true });
     }
   }
 
@@ -71,7 +73,7 @@ export function Spells({ spells }) {
             spell={spell}
             onSpellchange={updateSpellname}
             editing={currentlyEditing === index}
-            viewing={currentlyViewing === index}
+            viewing={index in currentlyViewing}
             onBeginEdit={tryBeginEdit}
             onEndEdit={tryEndEdit}
             onView={tryView}
@@ -117,29 +119,28 @@ function SpellItem({
   };
 
   if (!editing) {
-    if (viewing) {
-      return (
-        <>
-          <div className="spell-item-expanded" onClick={handleClick}>
-            {spellName}
-          </div>
-          <div className="spell-item-expanded-base">
-            <p>School: {spell.school}</p>
-            <p>Casting Time: {spell.castingTime}</p>
-            <p>Range: {spell.range}</p>
-            <p>Components: {spell.components}</p>
-            <p>Duration: {spell.duration}</p>
-            <p>{spell.description}</p>
-          </div>
-        </>
-      );
-    } else {
-      return (
-        <div id={id} className="spell-item" onClick={handleClick}>
+    return (
+      <>
+        <div
+          className={viewing ? "spell-item-expanded" : "spell-item"}
+          onClick={handleClick}
+        >
           {spellName}
         </div>
-      );
-    }
+        <div
+          className={
+            viewing ? "spell-item-expanded-base" : "spell-item-collapsed-base"
+          }
+        >
+          <p>School: {spell.school}</p>
+          <p>Casting Time: {spell.castingTime}</p>
+          <p>Range: {spell.range}</p>
+          <p>Components: {spell.components}</p>
+          <p>Duration: {spell.duration}</p>
+          <p>{spell.description}</p>
+        </div>
+      </>
+    );
   } else {
     return (
       <div className="Spell-Item-Editor-Row">


### PR DESCRIPTION
… expanded at once

Stores an object of the currently expanded spells and removes the spell id from the object when it is collapsed.
uses max-height to expand and collapse spell info


Branched off DanielsDev as there would have been some annoying conflicts otherwise